### PR TITLE
Update Rails Dependency

### DIFF
--- a/administrate-field-paperclip.gemspec
+++ b/administrate-field-paperclip.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split('\n')
 
   gem.add_dependency 'administrate', '~> 0.4'
-  gem.add_dependency 'rails', '>= 4.2', '< 5.1'
+  gem.add_dependency 'rails', '>= 4.2', '< 5.2'
 
   gem.add_development_dependency 'byebug'
   gem.add_development_dependency 'factory_girl'


### PR DESCRIPTION
This gem is compatible with Rails 5.1, but it is currently blocking that
version.  Relax the dependency to allow for use of Rails 5.1